### PR TITLE
Disable putting encrypted dependency info in the signing blocks

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,6 +35,13 @@ android {
         sourceCompatibility JavaVersion.VERSION_21
         targetCompatibility JavaVersion.VERSION_21
     }
+
+    dependenciesInfo {
+        // Disable including dependency metadata when building APKs
+        includeInApk = false
+        // Disable including dependency metadata when building Android App Bundles
+        includeInBundle = false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Data is only readable by google, we don't need them to know how the app was built

See https://android.izzysoft.de/articles/named/iod-scan-apkchecks#blobs for details

Thanks to @IzzySoft for pointing this out to me :) 
